### PR TITLE
Scheduled workflow for running performance benchmarks

### DIFF
--- a/.github/test-config.yaml
+++ b/.github/test-config.yaml
@@ -1,0 +1,19 @@
+test:
+  smp_version: v0.0.1
+  name: istio-test
+  labels: {}
+  clients:
+    - internal: false
+      load_generator: fortio
+      protocol: 1
+      connections: 2
+      rps: 5
+      headers: {}
+      cookies: {}
+      body: ''
+      content_type: ''
+      endpoint_urls:
+        - 'https://meshery.io'
+  duration: 6s
+mesh:
+  type: 3

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -1,0 +1,55 @@
+name: Scheduled Benchmark Tests
+on:
+  # for triggering manually, provide a token
+  workflow_dispatch:
+    inputs:
+      provider_token:
+        description: "token for remote provider"
+        required: false
+      profile_name:
+        description: "performance profile to use"
+        required: false
+        default: istio-benchmark
+  # scheduled to run at every Thursday at 13:22
+  schedule:
+    - cron: '22 13 * * THU'
+
+jobs:
+  manual-test:
+    name: Manual Benchmark Test
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Setup Kubernetes
+        uses: manusa/actions-setup-minikube@v2.4.1
+        with:
+          minikube version: 'v1.23.2'
+          kubernetes version: 'v1.22.2'
+          driver: docker
+        
+      - name: Run Benchmark Tests
+        uses: ../../
+        with:
+          provider_token: ${{ github.event.inputs.provider_token }}
+          platform: docker
+          profile_name: ${{ github.event.inputs.profile_name }}
+
+  scheduled-test:
+    name: Scheduled Benchmark Test
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'schedule' }}
+    steps:
+      - name: Setup Kubernetes
+        uses: manusa/actions-setup-minikube@v2.4.1
+        with:
+          minikube version: 'v1.23.2'
+          kubernetes version: 'v1.22.2'
+          driver: docker
+        
+      - name: Run Benchmark Tests
+        uses: ../../
+        with:
+          provider_token: ${{ secrets.MESHERY_TOKEN }}
+          platform: kubernetes
+          profile_name: istio-benchmark
+          

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           driver: docker
         
       - name: Run Benchmark Tests
-        uses: ./
+        uses: layer5io/meshery-smp-action
         with:
           provider_token: ${{ github.event.inputs.provider_token }}
           platform: docker
@@ -47,7 +47,7 @@ jobs:
           driver: docker
         
       - name: Run Benchmark Tests
-        uses: ./
+        uses: layer5io/meshery-smp-action
         with:
           provider_token: ${{ secrets.MESHERY_TOKEN }}
           platform: kubernetes

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -14,7 +14,7 @@ on:
         required: false
   # scheduled to run at every Thursday at 13:22
   schedule:
-    - cron: '22 13 * * THU'
+    - cron: '22 13 * * *'
 
 jobs:
   manual-test:

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -26,6 +26,10 @@ jobs:
           minikube version: 'v1.23.2'
           kubernetes version: 'v1.22.2'
           driver: docker
+
+      - name: Install Service Mesh and Deploy Application
+        run: |
+          ./scripts/istio_deploy.sh
         
       - name: Run Benchmark Tests
         uses: layer5io/meshery-smp-action@master
@@ -45,10 +49,14 @@ jobs:
           minikube version: 'v1.23.2'
           kubernetes version: 'v1.22.2'
           driver: docker
+
+      - name: Install Service Mesh and Deploy Application
+        run: |
+          ./scripts/istio_deploy.sh
         
       - name: Run Benchmark Tests
         uses: layer5io/meshery-smp-action@master
         with:
           provider_token: ${{ secrets.MESHERY_TOKEN }}
-          platform: kubernetes
+          platform: docker
           profile_name: istio-benchmark

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           driver: docker
         
       - name: Run Benchmark Tests
-        uses: ../../
+        uses: ./
         with:
           provider_token: ${{ github.event.inputs.provider_token }}
           platform: docker
@@ -47,9 +47,8 @@ jobs:
           driver: docker
         
       - name: Run Benchmark Tests
-        uses: ../../
+        uses: ./
         with:
           provider_token: ${{ secrets.MESHERY_TOKEN }}
           platform: kubernetes
           profile_name: istio-benchmark
-          

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -27,9 +27,14 @@ jobs:
           kubernetes version: 'v1.22.2'
           driver: docker
 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
       - name: Install Service Mesh and Deploy Application
         run: |
-          ./scripts/istio_deploy.sh
+          chmod +x .github/workflows/scripts/istio_deploy.sh
+          .github/workflows/scripts/istio_deploy.sh
+        shell: bash
         
       - name: Run Benchmark Tests
         uses: layer5io/meshery-smp-action@master
@@ -50,9 +55,14 @@ jobs:
           kubernetes version: 'v1.22.2'
           driver: docker
 
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
       - name: Install Service Mesh and Deploy Application
         run: |
-          ./scripts/istio_deploy.sh
+          chmod +x .github/workflows/scripts/istio_deploy.sh
+          .github/workflows/scripts/istio_deploy.sh
+        shell: bash
         
       - name: Run Benchmark Tests
         uses: layer5io/meshery-smp-action@master

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -28,7 +28,7 @@ jobs:
           driver: docker
         
       - name: Run Benchmark Tests
-        uses: layer5io/meshery-smp-action
+        uses: layer5io/meshery-smp-action@master
         with:
           provider_token: ${{ github.event.inputs.provider_token }}
           platform: docker
@@ -47,7 +47,7 @@ jobs:
           driver: docker
         
       - name: Run Benchmark Tests
-        uses: layer5io/meshery-smp-action
+        uses: layer5io/meshery-smp-action@master
         with:
           provider_token: ${{ secrets.MESHERY_TOKEN }}
           platform: kubernetes

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -9,7 +9,9 @@ on:
       profile_name:
         description: "performance profile to use"
         required: false
-        default: istio-benchmark
+      profile_filename:
+        description: "test configuration file"
+        required: false
   # scheduled to run at every Thursday at 13:22
   schedule:
     - cron: '22 13 * * THU'
@@ -42,6 +44,8 @@ jobs:
           provider_token: ${{ github.event.inputs.provider_token }}
           platform: docker
           profile_name: ${{ github.event.inputs.profile_name }}
+          profile_filename: ${{ github.event.inputs.profile_filename }}
+          endpoint_url: ${{env.ENDPOINT_URL}}
 
   scheduled-test:
     name: Scheduled Benchmark Test
@@ -70,3 +74,4 @@ jobs:
           provider_token: ${{ secrets.MESHERY_TOKEN }}
           platform: docker
           profile_name: istio-benchmark
+          profile_filename: istio-test-config

--- a/.github/workflows/scripts/istio_deploy.sh
+++ b/.github/workflows/scripts/istio_deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.11.4 sh -
+cd istio-1.11.4
+export PATH=$PWD/bin:$PATH
+istioctl install --set profile=demo -y
+kubectl label namespace default istio-injection=enabled
+kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+kubectl apply -f samples/bookinfo/networking/bookinfo-gateway.yaml
+sleep 100
+export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
+export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+export INGRESS_HOST=$(minikube ip)
+export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+minikube tunnel
+echo "$GATEWAY_URL"

--- a/.github/workflows/scripts/istio_deploy.sh
+++ b/.github/workflows/scripts/istio_deploy.sh
@@ -14,3 +14,4 @@ export INGRESS_HOST=$(minikube ip)
 export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
 minikube tunnel &
 echo "$GATEWAY_URL"
+echo "ENDPOINT_URL=$GATEWAY_URL" >> $GITHUB_ENV

--- a/.github/workflows/scripts/istio_deploy.sh
+++ b/.github/workflows/scripts/istio_deploy.sh
@@ -12,5 +12,5 @@ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -
 export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
 export INGRESS_HOST=$(minikube ip)
 export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
-minikube tunnel
+minikube tunnel &
 echo "$GATEWAY_URL"

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,12 @@ inputs:
     description: "Name of the performance profile"
     required: false
 
+  # overrides the endpoint_url specified in the tes configuration file
+  # use this for dynamically injecting the application endpoint while running the workflow
+  endpoint_url:
+    description: "Endpoint in which the application is deployed"
+    required: false
+
 runs:
   using: "node12"
   main: "main.js"

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ inputs:
   platform:
     description: "Platform to deploy Meshery to. Allowed values: docker, kubernetes"
     default: docker
+    required: false
 
   # provide either a test configuration file or a performance profile name
 
@@ -21,11 +22,13 @@ inputs:
   # store this file in the .github folder in your repository
   profile_filename:
     description: "Name of the test configuration file"
+    required: false
 
   # name of the performance profile to use to run tests
   # see: https://docs.meshery.io/functionality/performance-management#performance-profiles
   profile_name:
     description: "Name of the performance profile"
+    required: false
 
 runs:
   using: "node12"

--- a/main.sh
+++ b/main.sh
@@ -29,6 +29,10 @@ main() {
 		commandArgs=(--profile-name ${INPUT_PROFILE_NAME})
 	fi
 
+	if [[ -n "${INPUT_ENDPOINT_URL:-}" ]]; then
+		commandArgs=(--endpoint-url ${INPUT_ENDPOINT_URL})
+	fi
+
 	"$SCRIPT_DIR/mesheryctl.sh" "${commandArgs[@]}"
 }
 

--- a/main.sh
+++ b/main.sh
@@ -30,7 +30,7 @@ main() {
 	fi
 
 	if [[ -n "${INPUT_ENDPOINT_URL:-}" ]]; then
-		commandArgs=(--endpoint-url ${INPUT_ENDPOINT_URL})
+		commandArgs+=(--endpoint-url ${INPUT_ENDPOINT_URL})
 	fi
 
 	"$SCRIPT_DIR/mesheryctl.sh" "${commandArgs[@]}"

--- a/mesheryctl.sh
+++ b/mesheryctl.sh
@@ -43,8 +43,6 @@ main() {
 
 			mesheryctl system config minikube -t ~/auth.json
 
-			mesheryctl mesh deploy --adapter ${adapters["$service_mesh"]} -t ~/auth.json "$service_mesh" --watch
-
 		fi
 		mesheryctl perf apply $perf_profile_name -t ~/auth.json
 

--- a/mesheryctl.sh
+++ b/mesheryctl.sh
@@ -22,6 +22,17 @@ main() {
 	# perform the test given in the provided profile_id
 	if [ -z "$perf_profile_name" ]
 	then
+		for mesh in "${!adapters[@]}"
+		do
+			shortName=$(echo ${adapters["$mesh"]} | cut -d '-' -f2 | cut -d ':' -f1)
+
+			docker network connect bridge meshery_meshery-"$shortName"_1
+			docker network connect minikube meshery_meshery-"$shortName"_1
+		done
+
+		docker network connect bridge meshery_meshery_1
+		docker network connect minikube meshery_meshery_1
+		mesheryctl system config minikube -t ~/auth.json
 
 		mesheryctl perf apply --file $GITHUB_WORKSPACE/.github/$perf_filename -t ~/auth.json
 

--- a/mesheryctl.sh
+++ b/mesheryctl.sh
@@ -16,6 +16,7 @@ adapters["traefik_mesh"]=meshery-traefik-mesh:10006
 main() {
 	local perf_filename=
 	local perf_profile_name=
+	local endpoint_url=
 
 	parse_command_line "$@"
 
@@ -34,14 +35,13 @@ main() {
 		docker network connect minikube meshery_meshery_1
 		mesheryctl system config minikube -t ~/auth.json
 
-		mesheryctl perf apply --file $GITHUB_WORKSPACE/.github/$perf_filename -t ~/auth.json
+		mesheryctl perf apply --file $GITHUB_WORKSPACE/.github/$perf_filename -t ~/auth.json --url "$endpoint_url"
 
 	else
 
 		# get the mesh name from performance test config
 		service_mesh=$(mesheryctl perf view $perf_profile_name -t ~/auth.json -o json 2>&1 | jq '."service_mesh"' | tr -d '"')
 
-		# deploy the mentioned service mesh if needed
 		if [[ $service_mesh != "null" ]]
 		then
 
@@ -79,6 +79,15 @@ parse_command_line() {
 					shift
 				else
 					echo "ERROR: '--profile-id' cannot be empty." >&2
+					exit 1
+				fi
+				;;
+			--endpoint-url)
+				if [[ -n "${2:-}" ]]; then
+					endpoint_url=$2
+					shift
+				else
+					echo "ERROR: '--endpoint-url' cannot be empty." >&2
 					exit 1
 				fi
 				;;

--- a/mesheryctl.sh
+++ b/mesheryctl.sh
@@ -35,6 +35,9 @@ main() {
 		docker network connect minikube meshery_meshery_1
 		mesheryctl system config minikube -t ~/auth.json
 
+		echo "Configuration file: $perf_filename"
+		echo "Endpoint URL: $endpoint_url"
+
 		mesheryctl perf apply --file $GITHUB_WORKSPACE/.github/$perf_filename -t ~/auth.json --url "$endpoint_url"
 
 	else


### PR DESCRIPTION
**Description**

Updates the action to:

* support injecting dynamic endpoint urls (accompanying [PR in Meshery/mesheryctl](https://github.com/meshery/meshery/pull/4590))
* deploy adapters when running a test with a configuration file

Adds a new workflow that runs scheduled performance benchmarks that:

* Setups a Kubernetes cluster
* Deploys a service mesh and onboards an application (Currently only Istio. A build matrix or separate workflows can be made for benchmarking other service meshes as well)
* Deploys Meshery and Meshery Adapters
* Runs a performance test based on either the configuration file provided or a performance profile name
* The workflow can either be manually triggered or be scheduled to run at a fixed time (arbitrarily this is set to run every Thursday at 13:22)
* Both of these triggers are implemented

**TODO**

* Schedule action for multiple service meshes and multiple test configurations
* Setup secrets for the scheduled trigger

- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
