### PR TITLE
fix failing workflow run

### DIFF
--- a/.github/workflows/scripts/mesh_deploy.sh
+++ b/.github/workflows/scripts/mesh_deploy.sh
@@ -1,23 +1,15 @@
 MESH=$1
-
+MESHERYCTL="/usr/local/bin/mesheryctl"
 echo "Checking if mesheryctl is installed"
-	
-if mesheryctl
-	
-then
-	echo "Found mesheryctl, deploying $MESH"
+
+
+if [ -f "${MESHERYCTL}" ]; then
+    echo "Found mesheryctl, deploy $MESH"
 	mesheryctl mesh deploy $MESH
-	
-else
-	printf "Mesheryctl not found. \nInstalling...\n"
-	curl -L https://git.io/meshery | DEPLOY_MESHERY=false bash -
-	echo "Installed mesheryctl successfully!"
-	mesheryctl mesh deploy $MESH
-	
+   else
+      printf "Mesheryctl not found. \nInstalling...\n"
+	  curl -L https://git.io/meshery | DEPLOY_MESHERY=false bash -
+	  echo "Installed mesheryctl successfully!"
+	  mesheryctl mesh deploy $MESH
+     
 fi
-
-
-
-
-
-

--- a/.github/workflows/scripts/mesh_deploy.sh
+++ b/.github/workflows/scripts/mesh_deploy.sh
@@ -5,12 +5,12 @@ echo "Checking if mesheryctl is installed"
 if mesheryctl
 	
 then
-	echo "found mesheryctl, deploying $MESH"
+	echo "Found mesheryctl, deploying $MESH"
 	mesheryctl mesh deploy $MESH
 	
 else
 	printf "Mesheryctl not found. \nInstalling...\n"
-	install_mesheryctl
+	curl -L https://git.io/meshery | DEPLOY_MESHERY=false bash -
 	echo "Installed mesheryctl successfully!"
 	mesheryctl mesh deploy $MESH
 	
@@ -20,8 +20,4 @@ fi
 
 
 
-install_mesheryctl(){
-  curl -L https://github.com/meshery/meshery/releases/download/v0.5.67/mesheryctl_0.5.67_Linux_x86_64.zip -o mesheryctl.zip
-  unzip -n mesheryctl.zip 
-  mv mesheryctl /usr/local/bin/mesheryctl
-}
+

--- a/.github/workflows/scripts/mesh_deploy.sh
+++ b/.github/workflows/scripts/mesh_deploy.sh
@@ -5,7 +5,7 @@ echo "Checking if mesheryctl is installed"
 if mesheryctl
 	
 then
-	echo found mesheryctl, deploying $MESH
+	echo "found mesheryctl, deploying $MESH"
 	mesheryctl mesh deploy $MESH
 	
 else

--- a/.github/workflows/scripts/mesh_deploy.sh
+++ b/.github/workflows/scripts/mesh_deploy.sh
@@ -6,7 +6,7 @@ if mesheryctl
 	
 then
 	echo found mesheryctl, deploying $MESH
-	mesheryctl mesh deploy $mesh
+	mesheryctl mesh deploy $MESH
 	
 else
 	printf "Mesherycyl not found. \nInstalling...\n"

--- a/.github/workflows/scripts/mesh_deploy.sh
+++ b/.github/workflows/scripts/mesh_deploy.sh
@@ -1,6 +1,6 @@
 MESH=$1
 
-echo "checking if mesheryctl is installed"
+echo "Checking if mesheryctl is installed"
 	
 if mesheryctl
 	
@@ -9,7 +9,7 @@ then
 	mesheryctl mesh deploy $MESH
 	
 else
-	printf "Mesherycyl not found. \nInstalling...\n"
+	printf "Mesheryctl not found. \nInstalling...\n"
 	install_mesheryctl
 	echo "Installed mesheryctl successfully!"
 	mesheryctl mesh deploy $MESH

--- a/.github/workflows/scripts/mesh_deploy.sh
+++ b/.github/workflows/scripts/mesh_deploy.sh
@@ -2,14 +2,12 @@ MESH=$1
 MESHERYCTL="/usr/local/bin/mesheryctl"
 echo "Checking if mesheryctl is installed"
 
-
-if [ -f "${MESHERYCTL}" ]; then
-    echo "Found mesheryctl, deploy $MESH"
+if [  -f $MESHERYCTL ]; then
+        echo "Found mesheryctl, deploy $MESH"
 	mesheryctl mesh deploy $MESH
-   else
-      printf "Mesheryctl not found. \nInstalling...\n"
-	  curl -L https://git.io/meshery | DEPLOY_MESHERY=false bash -
-	  echo "Installed mesheryctl successfully!"
-	  mesheryctl mesh deploy $MESH
-     
-fi
+    else
+        printf "Mesheryctl not found. \nInstalling...\n"
+	curl -L https://git.io/meshery | DEPLOY_MESHERY=false bash -
+	echo "Installed mesheryctl successfully!"
+	mesheryctl mesh deploy $MESH
+    fi

--- a/.github/workflows/scripts/mesh_deploy.sh
+++ b/.github/workflows/scripts/mesh_deploy.sh
@@ -1,0 +1,27 @@
+MESH=$1
+
+echo "checking if mesheryctl is installed"
+	
+if mesheryctl
+	
+then
+	echo found mesheryctl, deploying $MESH
+	mesheryctl mesh deploy $mesh
+	
+else
+	printf "Mesherycyl not found. \nInstalling...\n"
+	install_mesheryctl
+	echo "Installed mesheryctl successfully!"
+	mesheryctl mesh deploy $MESH
+	
+fi
+
+
+
+
+
+install_mesheryctl(){
+  curl -L https://github.com/meshery/meshery/releases/download/v0.5.67/mesheryctl_0.5.67_Linux_x86_64.zip -o mesheryctl.zip
+  unzip -n mesheryctl.zip 
+  mv mesheryctl /usr/local/bin/mesheryctl
+}

--- a/.github/workflows/scripts/osm_deploy.sh
+++ b/.github/workflows/scripts/osm_deploy.sh
@@ -8,7 +8,7 @@
 export MESH_NAME='Open Service Mesh'
 export SERVICE_MESH='OPEN_SERVICE_MESH'
 
-system=$(uname -s)
+system=$(uname -s |  tr '[:upper:]' '[:lower:]')
 release=v0.11.1
 curl -L https://github.com/openservicemesh/osm/releases/download/${release}/osm-${release}-${system}-amd64.tar.gz | tar -vxzf - ./${system}-amd64/osm version
 osm install \


### PR DESCRIPTION
**Description**
the last workflow [run](https://github.com/layer5io/meshery-smp-action/runs/4264742948?check_suite_focus=true) for osm failed. this was caused by a case mismatch in the name of the osm binary
This PR fixes #
https://github.com/layer5io/meshery-smp-action/runs/4264742948?check_suite_focus=true
**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
