### PR TITLE
Ensure that Istio application endpoint is reachable from Meshery

### DIFF
--- a/.github/workflows/scripts/istio_deploy.sh
+++ b/.github/workflows/scripts/istio_deploy.sh
@@ -27,10 +27,10 @@ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressga
 export INGRESS_HOST=$(minikube ip)
 export GATEWAY_URL=http://$INGRESS_HOST:$INGRESS_PORT
 
-minikube tunnel &
+minikube tunnel &> /dev/null &
 
 echo "Service Mesh: $MESH_NAME - $SERVICE_MESH"
 echo "Gateway URL: $GATEWAY_URL"
 
-echo "ENDPOINT_URL=$GATEWAY_URL" >> $GITHUB_ENV
+echo "ENDPOINT_URL=$GATEWAY_URL/productpage" >> $GITHUB_ENV
 echo "SERVICE_MESH=$SERVICE_MESH" >> $GITHUB_ENV


### PR DESCRIPTION
Signed-off-by: Xin Huang <xin1.huang@intel.com>

**Description**

This PR fixes #27 

1. Replace `minikube tunnel` command with `minikube tunnel &> /dev/null &` to avoid the tunnel getting killed.
2. Change the default endpoint_url to make sure it's reachable from Meshery.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
