### PR TITLE
Self hosted runner

### DIFF
--- a/.github/workflows/configurable-benchmark-test.yaml
+++ b/.github/workflows/configurable-benchmark-test.yaml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         
       - name: Run Benchmark Tests
-        uses: hershd23/meshery-smp-action@self-hosted-runner
+        uses: layer5io/meshery-smp-action@self-hosted
         with:
           provider_token: ${{ secrets.MESHERY_TOKEN }}
           platform: docker

--- a/.github/workflows/configurable-benchmark-test.yaml
+++ b/.github/workflows/configurable-benchmark-test.yaml
@@ -31,15 +31,16 @@ on:
 jobs:
   manual-test:
     name: Configurable Benchmark Test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Setup Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.1
+        uses: manusa/actions-setup-minikube@v2.4.3
         with:
           minikube version: 'v1.23.2'
-          kubernetes version: 'v1.22.2'
+          kubernetes version: 'v1.23.2'
           driver: docker
+          start args: "--v=5"
 
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -51,7 +52,7 @@ jobs:
         shell: bash
         
       - name: Run Benchmark Tests
-        uses: layer5io/meshery-smp-action@master
+        uses: hershd23/meshery-smp-action@self-hosted-runner
         with:
           provider_token: ${{ secrets.MESHERY_TOKEN }}
           platform: docker


### PR DESCRIPTION
**Description**

We are currently able to run Configurable-benchmark-test on Docker platform and bumps the setup minikube action version to 2.4.3.

**Notes for Reviewers**
Given that all the heavy lifting has been done with the instance and the OS permissions, the changes here are rather minor.
This new branch servers as a dev branch to while we figure out the self-hosted-runners piece.

Successful CI run :- https://github.com/hershd23/meshery-smp-action/runs/5173891017?check_suite_focus=true

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
