### PR TITLE
Add default timeouts for jobs

### DIFF
--- a/.github/workflows/configurable-benchmark-test-self-hosted.yaml
+++ b/.github/workflows/configurable-benchmark-test-self-hosted.yaml
@@ -27,6 +27,7 @@ on:
 jobs:
   start-runner:
     name: Start self-hosted CNCF CIL runner
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}
     outputs:
@@ -62,6 +63,7 @@ jobs:
 
   run-benchmarks:
     name: Run the configurable benchmarks on the runner
+    timeout-minutes: 60
     needs: 
        - start-runner # required to start the main job when the runner is ready
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
@@ -111,6 +113,7 @@ jobs:
 
   stop-runner:
     name: Stop self-hosted runner
+    timeout-minutes: 60
     needs:
       - start-runner # required to get output from the start-runner job
       - run-benchmarks # required to wait when the main job is done

--- a/.github/workflows/scheduled-benchmarks-self-hosted.yaml
+++ b/.github/workflows/scheduled-benchmarks-self-hosted.yaml
@@ -20,6 +20,7 @@ jobs:
   # Manual Benchmark Test
   start-runners-manual:
     name: Start self-hosted CNCF CIL runners for manual test
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}
     strategy:
@@ -60,6 +61,7 @@ jobs:
 
   manual-test:
     name: Manual Benchmark Test
+    timeout-minutes: 60
     needs:
       - start-runners-manual
     runs-on: ${{ matrix.service-mesh }}-${{ matrix.load-generator }}-${{ github.run_id }}
@@ -119,6 +121,7 @@ jobs:
 
   stop-runner-manual:
     name: Stop self-hosted runner
+    timeout-minutes: 60
     needs:
       - start-runners-manual # required to get output from the start-runner job
       - manual-test # required to wait when the main job is done
@@ -148,6 +151,7 @@ jobs:
   # Scheduled Benchmark Test
   start-runners-scheduled:
     name: Start self-hosted CNCF CIL runners for scheduled test
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'schedule' }}
     strategy:
@@ -189,6 +193,7 @@ jobs:
 
   scheduled-test:
     name: Scheduled Benchmark Test
+    timeout-minutes: 60
     needs:
       - start-runners-scheduled
     runs-on: ${{ matrix.service-mesh }}-${{ matrix.load-generator }}-${{ matrix.test-configuration }}-${{ github.run_id }}
@@ -249,6 +254,7 @@ jobs:
 
   stop-runner-scheduled:
     name: Stop self-hosted runner
+    timeout-minutes: 60
     needs:
       - start-runners-scheduled # required to get output from the start-runner job
       - scheduled-test # required to wait when the main job is done


### PR DESCRIPTION
Signed-off-by: Huang Xin <xin1.huang@intel.com>

**Description**

Add default timeouts for jobs to avoid workflow being always pending due to one failed job.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
