### PR TITLE
Fix stop runners failures

### DIFF
--- a/.github/workflows/configurable-benchmark-test-self-hosted.yaml
+++ b/.github/workflows/configurable-benchmark-test-self-hosted.yaml
@@ -127,6 +127,7 @@ jobs:
         shell: bash
 
       - name: Remove CNCF CIL runner from github repository
+        if: always()
         run: |
           runner_id=$(curl -s -H 'Authorization: token ${{ secrets.GH_ACCESS_TOKEN }}' -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{github.repository}}/actions/runners | jq '.runners[] | select(.name == "${{ needs.start-runner.outputs.hostname }}") | {id}' | jq -r .id)
           curl -X DELETE -H 'Authorization: token ${{ secrets.GH_ACCESS_TOKEN }}' -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{github.repository}}/actions/runners/$runner_id

--- a/.github/workflows/scheduled-benchmarks-self-hosted.yaml
+++ b/.github/workflows/scheduled-benchmarks-self-hosted.yaml
@@ -140,6 +140,7 @@ jobs:
         shell: bash
 
       - name: Remove CNCF CIL runner from github repository
+        if: always()
         run: |
           runner_id=$(curl -s -H 'Authorization: token ${{ secrets.GH_ACCESS_TOKEN }}' -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{github.repository}}/actions/runners | jq '.runners[] | select(.name == "${{ matrix.service-mesh }}-${{ matrix.load-generator }}-${{ needs.start-runners-manual.outputs.github_run_id }}") | {id}' | jq -r .id)
           curl -X DELETE -H 'Authorization: token ${{ secrets.GH_ACCESS_TOKEN }}' -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{github.repository}}/actions/runners/$runner_id
@@ -271,6 +272,7 @@ jobs:
         shell: bash
 
       - name: Remove CNCF CIL runner from github repository
+        if: always()
         run: |
           runner_id=$(curl -s -H 'Authorization: token ${{ secrets.GH_ACCESS_TOKEN }}' -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{github.repository}}/actions/runners | jq '.runners[] | select(.name == "${{ matrix.service-mesh }}-${{ matrix.load-generator }}-${{ matrix.test-configuration }}-${{ needs.start-runners-scheduled.outputs.github_run_id }}") | {id}' | jq -r .id)
           curl -X DELETE -H 'Authorization: token ${{ secrets.GH_ACCESS_TOKEN }}' -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{github.repository}}/actions/runners/$runner_id

--- a/.github/workflows/scripts/stop-cil-runner.sh
+++ b/.github/workflows/scripts/stop-cil-runner.sh
@@ -9,7 +9,7 @@ device_id=$3
 if [[ -z $device_id ]]; then
     # If it's a scheduled benchmark test, we cannot get the orrespondence between hostname and
     # device_id from previous job, so we need to use hostname to retrive device_id
-    device_id=$(curl -H "X-Auth-Token: $token " https://api.equinix.com/metal/v1/projects/96a9d336-541b-42f7-9827-d845010da550/devices | jq '.devices[] | select(.hostname == '\"$hostname\"') | {id}' | jq -r .id)
+    device_id=$(curl -H "X-Auth-Token: $token " https://api.equinix.com/metal/v1/projects/96a9d336-541b-42f7-9827-d845010da550/devices?hostname=${hostname} | jq '.devices[] | {id}' | jq -r .id)
 fi
 
 echo "Removing CNCF CIL machine: $hostname, device id: $device_id..."


### PR DESCRIPTION
If it's a scheduled benchmark test, we retrives all devices to get
device id of each machine, which often cause failures due to its large
query. After this change, we use hostname to retrive device id of each
machine, it will fix above failures.

Signed-off-by: Huang Xin <xin1.huang@intel.com>


This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
