### PR TITLE
[Bug] Fix K8s config unavailable to Meshery server 

### DIFF
--- a/.github/workflows/scheduled-benchmarks-self-hosted.yaml
+++ b/.github/workflows/scheduled-benchmarks-self-hosted.yaml
@@ -86,6 +86,8 @@ jobs:
           sudo apt-cache policy docker-ce
           sudo apt install -y docker-ce
           sudo systemctl status docker
+          sudo mkdir -p ~/.kube
+          sudo chmod 777 ~/.kube
 
       - name: Setup Kubernetes
         uses: manusa/actions-setup-minikube@v2.4.3
@@ -220,6 +222,8 @@ jobs:
           sudo apt-cache policy docker-ce
           sudo apt install -y docker-ce
           sudo systemctl status docker
+          sudo mkdir -p ~/.kube
+          sudo chmod 777 ~/.kube
 
       - name: Setup Kubernetes
         uses: manusa/actions-setup-minikube@v2.4.3

--- a/.github/workflows/scheduled-benchmarks.yml
+++ b/.github/workflows/scheduled-benchmarks.yml
@@ -28,10 +28,10 @@ jobs:
         load-generator: ['fortio', 'wrk2']
     steps:
       - name: Setup Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.1
+        uses: manusa/actions-setup-minikube@v2.4.3
         with:
           minikube version: 'v1.23.2'
-          kubernetes version: 'v1.22.2'
+          kubernetes version: 'v1.23.2'
           driver: docker
 
       - name: Checkout Code
@@ -71,10 +71,10 @@ jobs:
         test-configuration: ['load-test.yaml','soak-test.yaml']
     steps:
       - name: Setup Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.1
+        uses: manusa/actions-setup-minikube@v2.4.3
         with:
           minikube version: 'v1.23.2'
-          kubernetes version: 'v1.22.2'
+          kubernetes version: 'v1.23.2'
           driver: docker
 
       - name: Checkout Code


### PR DESCRIPTION
Signed-off-by: Pranav Singh <pranavsingh02@hotmail.com>

**Description**
This PR: 
1. Updates `install dependencies` step to create and give proper permission to `~/.kube` dir
2. Updates install minikube-setup action to the latest version.

Possibly aims to solve this problem:
https://github.com/layer5io/meshery-smp-action/runs/6424151872?check_suite_focus=true#step:7:1368

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
4. Build and test your changes before submitting a PR. 
5. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
