### PR TITLE
fix: use Layer5 provider for cloud token authentication

### DIFF
--- a/meshery.sh
+++ b/meshery.sh
@@ -28,7 +28,7 @@ main() {
 		printf "Token not provided.\nUsing local provider...\n"
 		echo '{ "meshery-provider": "None", "token": null }' | jq -c '.token = ""'> ~/auth.json
 	else
-		echo '{ "meshery-provider": "Meshery", "token": null }' | jq -c '.token = "'$provider_token'"' > ~/auth.json
+		echo '{ "meshery-provider": "Layer5", "token": null }' | jq -c '.token = "'$provider_token'"' > ~/auth.json
 	fi
 	cat ~/auth.json
 


### PR DESCRIPTION
### Description
Changes meshery-provider from "Meshery" to "Layer5" in meshery.sh to enable authentication with Layer5 Cloud when a provider token is supplied.

This PR fixes #105

**Notes for Reviewers**

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
